### PR TITLE
Update Bijira URL

### DIFF
--- a/open-ai-api/README.md
+++ b/open-ai-api/README.md
@@ -19,7 +19,7 @@ The following steps will guide you through the process of creating and deploying
 
 ### Create the API Proxy
 
-1. Visit [https://preview-dv.bijira.dev/](https://preview-dv.bijira.dev/) and sign in to your account.
+1. Visit [https://console.bijira.dev/](https://console.bijira.dev/) and sign in to your account.
 2. Click the **Create** button in the **Component Listing** section.
 3. Under **Create API Proxy for Third-Party APIs (Egress)**, select the **AI API** option.
 4. Choose **OpenAI** from the list of AI providers.

--- a/openweathermap-api/README.md
+++ b/openweathermap-api/README.md
@@ -19,7 +19,7 @@ The following steps will guide you through the process of creating and deploying
 
 ### Create the API Proxy
 
-1. Visit [https://preview-dv.bijira.dev/](https://preview-dv.bijira.dev/) and sign in to your account.
+1. Visit [https://console.bijira.dev/](https://console.bijira.dev/) and sign in to your account.
 2. Click the **Create** button in the **Component Listing** section.
 3. Under **Create API Proxy for Third-Party APIs (Egress)**, select the **Get from Marketplace** option.
 4. Choose **OpenWeatherMap** from the list of available APIs.

--- a/reading-list-api/README.md
+++ b/reading-list-api/README.md
@@ -22,7 +22,7 @@ The following steps will guide you through the process of creating and deploying
 
 ### Create the API Proxy
 
-1. Go to [https://preview-dv.bijira.dev/](https://preview-dv.bijira.dev/) and sign in. This opens the project home page.
+1. Go to [https://console.bijira.dev/](https://console.bijira.dev/) and sign in. This opens the project home page.
 2. Click **Create** button in the Component Listing section. 
 3. Choose **Create API Proxy for My APIs (Ingress)** option and select **Import API Contract**.
 4. Select **URL** option and provide the following URL to import the API contract from the GitHub repository:


### PR DESCRIPTION
## Purpose
This pull request updates the URLs in the README files for various API projects to ensure they point to the correct Bijira console URL. The most important changes include modifying the sign-in URL in the instructions for creating API proxies.

Updates to README files:

* [`open-ai-api/README.md`](diffhunk://#diff-e3715aab9dbd009532c165b7304fce83b52a8ed79e84aadeea148a16250963e6L22-R22): Changed the sign-in URL from `https://preview-dv.bijira.dev/` to `https://console.bijira.dev/`.
* [`openweathermap-api/README.md`](diffhunk://#diff-ba0d935ab25434ba26b9fdf5144696b578f2aae5e9cc0c6fc0e1e36a782dd9f8L22-R22): Changed the sign-in URL from `https://preview-dv.bijira.dev/` to `https://console.bijira.dev/`.
* [`reading-list-api/README.md`](diffhunk://#diff-4ac3fd9efe69702fbd68b8d8e9c5c7241fc5faae9315899081d950e8f7925b5dL25-R25): Changed the sign-in URL from `https://preview-dv.bijira.dev/` to `https://console.bijira.dev/`.