### PR TITLE
Update Reading List API Service URL

### DIFF
--- a/reading-list-api/open-api.yaml
+++ b/reading-list-api/open-api.yaml
@@ -5,7 +5,7 @@ info:
   contact: {}
   version: "1.0"
 servers:
-  - url: https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/godzilla/reading-list-api-service/v1.0
+  - url: https://apis.bijira.dev/samples/reading-list-api-service/v1.0
 paths:
   /books:
     get:


### PR DESCRIPTION
## Purpose

This pull request includes an update to the `reading-list-api/open-api.yaml` file to change the server URL.

* [`reading-list-api/open-api.yaml`](diffhunk://#diff-eb6857ea11eb11be05e1b2cb820f9ccc0362d336b3729eafdcd7a932a4943fe5L8-R8): Updated the server URL from `https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/godzilla/reading-list-api-service/v1.0` to `https://apis.bijira.dev/samples/reading-list-api-service/v1.0`.