### PR TITLE
Remove the prefix / from the WebSub sample topic

### DIFF
--- a/github-api-websub/asyncapi.yaml
+++ b/github-api-websub/asyncapi.yaml
@@ -27,7 +27,7 @@ servers:
     protocol: http
     description: The endpoint where the subscriber listens for incoming WebSub notifications.
 channels:
-  /issues:
+  issues:
     description: The channel/topic for receiving updates related to Git issues.
     subscribe:
       operationId: receiveGitIssueEvent


### PR DESCRIPTION
## Purpose
> $subject, since Kafka doesn't accept `/`s. This change is temporary, until topic normalization is properly implemented